### PR TITLE
Wake screen on threat

### DIFF
--- a/app/src/main/kotlin/org/itxsvv/kxradar/Extensions.kt
+++ b/app/src/main/kotlin/org/itxsvv/kxradar/Extensions.kt
@@ -35,6 +35,7 @@ data class RadarSettings(
     val passedBeep: Beep,
     val inRideOnly: Boolean = false,
     val enabled: Boolean = true,
+    val wakeScreen: Boolean = true,
 ) {
     companion object {
         val defaultSettings = Json.encodeToString(RadarSettings())
@@ -43,7 +44,9 @@ data class RadarSettings(
     constructor() : this(
         Beep(200, 100),
         Beep(0, 100),
-        false, true
+        false,
+        true,
+        true
     )
 }
 

--- a/app/src/main/kotlin/org/itxsvv/kxradar/KarooRadarExtension.kt
+++ b/app/src/main/kotlin/org/itxsvv/kxradar/KarooRadarExtension.kt
@@ -6,6 +6,7 @@ import io.hammerhead.karooext.extension.KarooExtension
 import io.hammerhead.karooext.models.DataType
 import io.hammerhead.karooext.models.RideState
 import io.hammerhead.karooext.models.StreamState
+import io.hammerhead.karooext.models.TurnScreenOn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -48,8 +49,11 @@ class KarooRadarExtension : KarooExtension("kxradar", "1.0.3") {
                         ((settings.inRideOnly && rideState is RideState.Recording) || !settings.inRideOnly)
                     ) {
                         if (!radarThreat && threatLevel > 0) {
-                            Log.i(TAG, "Threat detected")
+                            Log.i(TAG, "Threat detected: " + threatLevel.toString())
                             passedDelay = 0
+                            if (settings.wakeScreen) {
+                                karooSystem.dispatch(TurnScreenOn)
+                            }
                             karooSystem.beep(settings.threatBeep.frequency, settings.threatBeep.duration)
                         }
                         if(passedDelay > 0 && System.currentTimeMillis() - passedDelay > DELAY_BEEP_ALL_CLEAR) {

--- a/app/src/main/kotlin/org/itxsvv/kxradar/screens/MainScreen.kt
+++ b/app/src/main/kotlin/org/itxsvv/kxradar/screens/MainScreen.kt
@@ -62,6 +62,7 @@ fun MainScreen() {
     var uiPassedBeep by remember { mutableStateOf(Beep(0, 0)) }
     var uiInRideOnlyEnabled by remember { mutableStateOf(true) }
     var uiBeepEnabled by remember { mutableStateOf(true) }
+    var uiWakeScreen by remember { mutableStateOf(true) }
 
     fun saveUISettings() {
         scope.launch {
@@ -69,7 +70,8 @@ fun MainScreen() {
                 threatBeep = uiThreatBeep,
                 passedBeep = uiPassedBeep,
                 inRideOnly = uiInRideOnlyEnabled,
-                enabled = uiBeepEnabled
+                enabled = uiBeepEnabled,
+                wakeScreen = uiWakeScreen
             )
             saveSettings(ctx, radarSettings)
         }
@@ -81,6 +83,7 @@ fun MainScreen() {
             uiPassedBeep = settings.passedBeep
             uiInRideOnlyEnabled = settings.inRideOnly
             uiBeepEnabled = settings.enabled
+            uiWakeScreen = settings.wakeScreen
         }
     }
 
@@ -125,6 +128,17 @@ fun MainScreen() {
             )
             Spacer(modifier = Modifier.width(10.dp))
             Text(modifier = Modifier.weight(1f), text = "In-ride only")
+        }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Switch(
+                modifier = Modifier.weight(1f),
+                checked = uiWakeScreen,
+                onCheckedChange = {
+                    uiWakeScreen = it
+                }
+            )
+            Spacer(modifier = Modifier.width(10.dp))
+            Text(modifier = Modifier.weight(1f), text = "Wake Screen")
         }
         FilledTonalButton(modifier = Modifier
             .fillMaxWidth()


### PR DESCRIPTION
If powersave mode is enabled and the radar is muted, Karoo also fails to turn the screen on.

This adds a setting toggle which will wake the screen when a radar detection occurs.